### PR TITLE
feat(VR): add allowRotation setting

### DIFF
--- a/include/Settings.h
+++ b/include/Settings.h
@@ -33,6 +33,7 @@ namespace DME
 		bool allowRightAttack[kTotal];
 		bool allowHotkeys[kTotal];
 		bool allowShout[kTotal];
+		bool allowRotation[kTotal];
 		
 		// Auto-close
 		bool autoCloseMenus;

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -69,12 +69,18 @@ namespace DME
 
 						//Rotation
 						#ifdef SKYRIMVR
-						if (settings->allowRotation[controlType])
+						if (settings->allowRotation[controlType] && evn->GetEventType() == RE::INPUT_EVENT_TYPE::kThumbstick)
 						{
-							if (settings->rightHandControl)
-								idEvent->userEvent = evn->device == RE::INPUT_DEVICES::INPUT_DEVICE::kVRRight && idEvent->userEvent == userEvents->leftStick ? userEvents->look : idEvent->userEvent;
-							else
-								idEvent->userEvent = evn->device == RE::INPUT_DEVICES::INPUT_DEVICE::kVRLeft && idEvent->userEvent == userEvents->leftStick ? userEvents->look : idEvent->userEvent;
+							RE::ThumbstickEvent* thumbEvent = static_cast<RE::ThumbstickEvent*>(evn);
+							bool isHorizontal = std::fabs(thumbEvent->xValue) > std::fabs(thumbEvent->yValue) * 2.0f; //Bias towards dialogue option selection 60 vs 30 degrees
+
+							if (isHorizontal)
+							{
+								if (settings->rightHandControl)
+									idEvent->userEvent = evn->device == RE::INPUT_DEVICES::INPUT_DEVICE::kVRRight && idEvent->userEvent == userEvents->leftStick ? userEvents->look : idEvent->userEvent;
+								else
+									idEvent->userEvent = evn->device == RE::INPUT_DEVICES::INPUT_DEVICE::kVRLeft && idEvent->userEvent == userEvents->leftStick ? userEvents->look : idEvent->userEvent;
+							}
 						}
 						#endif
 

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -65,8 +65,18 @@ namespace DME
 							else
 								idEvent->userEvent = evn->device == RE::INPUT_DEVICES::INPUT_DEVICE::kVRRight && idEvent->userEvent == userEvents->leftStick ? userEvents->move : idEvent->userEvent;
 							#endif
-
 						}
+
+						//Rotation
+						#ifdef SKYRIMVR
+						if (settings->allowRotation[controlType])
+						{
+							if (settings->rightHandControl)
+								idEvent->userEvent = evn->device == RE::INPUT_DEVICES::INPUT_DEVICE::kVRRight && idEvent->userEvent == userEvents->leftStick ? userEvents->look : idEvent->userEvent;
+							else
+								idEvent->userEvent = evn->device == RE::INPUT_DEVICES::INPUT_DEVICE::kVRLeft && idEvent->userEvent == userEvents->leftStick ? userEvents->look : idEvent->userEvent;
+						}
+						#endif
 
 						//Run
 						if (settings->allowRun[controlType] && controlMap->GetMappedKey(userEvents->run, idEvent->device.get(), GAMEPLAY_CONTEXT) == idEvent->idCode)

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -44,7 +44,6 @@ namespace DME
 		settings->allowRightAttack[ControlType::kKeyboardMouse] = ini.GetBoolValue("CONTROLS_KEYBOARD", "bAllowRightAttack", false);
 		settings->allowHotkeys[ControlType::kKeyboardMouse] = ini.GetBoolValue("CONTROLS_KEYBOARD", "bAllowHotkeys", false);
 		settings->allowShout[ControlType::kKeyboardMouse] = ini.GetBoolValue("CONTROLS_KEYBOARD", "bAllowShout", false);
-		settings->allowRotation[ControlType::kKeyboardMouse] = ini.GetBoolValue("CONTROLS_KEYBOARD", "bAllowRotation", false);
 
 		ini.SetBoolValue("CONTROLS_KEYBOARD", "bAllowMovement", settings->allowMovement[ControlType::kKeyboardMouse], nullptr, true);
 		ini.SetBoolValue("CONTROLS_KEYBOARD", "bAllowRun", settings->allowRun[ControlType::kKeyboardMouse], nullptr, true);
@@ -58,7 +57,6 @@ namespace DME
 		ini.SetBoolValue("CONTROLS_KEYBOARD", "bAllowRightAttack", settings->allowRightAttack[ControlType::kKeyboardMouse], nullptr, true);
 		ini.SetBoolValue("CONTROLS_KEYBOARD", "bAllowHotkeys", settings->allowHotkeys[ControlType::kKeyboardMouse], nullptr, true);
 		ini.SetBoolValue("CONTROLS_KEYBOARD", "bAllowShout", settings->allowShout[ControlType::kKeyboardMouse], nullptr, true);
-		ini.SetBoolValue("CONTROLS_KEYBOARD", "bAllowRotation", settings->allowRotation[ControlType::kKeyboardMouse], nullptr, true);
 
 		// Controls - controller
 		settings->allowMovement[ControlType::kController] = ini.GetBoolValue("CONTROLS_CONTROLLER", "bAllowMovement", true);

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -44,6 +44,7 @@ namespace DME
 		settings->allowRightAttack[ControlType::kKeyboardMouse] = ini.GetBoolValue("CONTROLS_KEYBOARD", "bAllowRightAttack", false);
 		settings->allowHotkeys[ControlType::kKeyboardMouse] = ini.GetBoolValue("CONTROLS_KEYBOARD", "bAllowHotkeys", false);
 		settings->allowShout[ControlType::kKeyboardMouse] = ini.GetBoolValue("CONTROLS_KEYBOARD", "bAllowShout", false);
+		settings->allowRotation[ControlType::kKeyboardMouse] = ini.GetBoolValue("CONTROLS_KEYBOARD", "bAllowRotation", false);
 
 		ini.SetBoolValue("CONTROLS_KEYBOARD", "bAllowMovement", settings->allowMovement[ControlType::kKeyboardMouse], nullptr, true);
 		ini.SetBoolValue("CONTROLS_KEYBOARD", "bAllowRun", settings->allowRun[ControlType::kKeyboardMouse], nullptr, true);
@@ -57,6 +58,7 @@ namespace DME
 		ini.SetBoolValue("CONTROLS_KEYBOARD", "bAllowRightAttack", settings->allowRightAttack[ControlType::kKeyboardMouse], nullptr, true);
 		ini.SetBoolValue("CONTROLS_KEYBOARD", "bAllowHotkeys", settings->allowHotkeys[ControlType::kKeyboardMouse], nullptr, true);
 		ini.SetBoolValue("CONTROLS_KEYBOARD", "bAllowShout", settings->allowShout[ControlType::kKeyboardMouse], nullptr, true);
+		ini.SetBoolValue("CONTROLS_KEYBOARD", "bAllowRotation", settings->allowRotation[ControlType::kKeyboardMouse], nullptr, true);
 
 		// Controls - controller
 		settings->allowMovement[ControlType::kController] = ini.GetBoolValue("CONTROLS_CONTROLLER", "bAllowMovement", true);
@@ -71,6 +73,7 @@ namespace DME
 		settings->allowRightAttack[ControlType::kController] = ini.GetBoolValue("CONTROLS_CONTROLLER", "bAllowRightAttack", false);
 		settings->allowHotkeys[ControlType::kController] = ini.GetBoolValue("CONTROLS_CONTROLLER", "bAllowHotkeys", false);
 		settings->allowShout[ControlType::kController] = ini.GetBoolValue("CONTROLS_CONTROLLER", "bAllowShout", false);
+		settings->allowRotation[ControlType::kController] = ini.GetBoolValue("CONTROLS_CONTROLLER", "bAllowRotation", false);
 
 		ini.SetBoolValue("CONTROLS_CONTROLLER", "bAllowMovement", settings->allowMovement[ControlType::kController], nullptr, true);
 		ini.SetBoolValue("CONTROLS_CONTROLLER", "bAllowRun", settings->allowRun[ControlType::kController], nullptr, true);
@@ -84,6 +87,7 @@ namespace DME
 		ini.SetBoolValue("CONTROLS_CONTROLLER", "bAllowRightAttack", settings->allowRightAttack[ControlType::kController], nullptr, true);
 		ini.SetBoolValue("CONTROLS_CONTROLLER", "bAllowHotkeys", settings->allowHotkeys[ControlType::kController], nullptr, true);
 		ini.SetBoolValue("CONTROLS_CONTROLLER", "bAllowShout", settings->allowShout[ControlType::kController], nullptr, true);
+		ini.SetBoolValue("CONTROLS_CONTROLLER", "bAllowRotation", settings->allowRotation[ControlType::kController], nullptr, true);
 
 		//Auto-close
 		settings->autoCloseMenus = ini.GetBoolValue("AUTOCLOSE", "bAutoCloseMenus", true);


### PR DESCRIPTION
Rotates left-right and dialogue option select up-down with thumbstick.

allowRotation set to false by default, but you can set it to true by default if you want. Your call. For me it works great.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new "Allow Rotation" control setting that enables independent configuration of rotation behavior for each supported input type or controller. Users can now customize which input devices support rotation through the configuration menu. All preferences are automatically saved and applied on subsequent application launches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->